### PR TITLE
Update result for `test_do_a_lot_of_silly_stuff`

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -111,7 +111,7 @@ class RoverTest(unittest.TestCase):
         rover = Rover(position, direction)
         commands = ('r', 'f', 'f', 'f', 'b', 'r')
         rover.execute(commands)
-        self.assertEquals(Position(0, -2), rover.get_position())
+        self.assertEquals(Position(-2, 0), rover.get_position())
         self.assertEquals(Direction.N, rover.get_direction())
 
 if __name__ == '__main__':


### PR DESCRIPTION
The unit test `test_do_a_lot_of_silly_stuff` should expect `Position(-2,0)` instead of `Position(0,-2)`

Addresses https://github.com/mfreyre/mars-rover-python/issues/1